### PR TITLE
Update _list.php

### DIFF
--- a/widgets/views/_list.php
+++ b/widgets/views/_list.php
@@ -46,9 +46,7 @@ use yii2mod\editable\Editable;
 <?php if ($model->hasChildren()) : ?>
     <ul class="children">
         <?php foreach ($model->getChildren() as $children) : ?>
-            <li class="comment" id="comment-<?php echo $children->id; ?>">
-                <?php echo $this->render('_list', ['model' => $children, 'maxLevel' => $maxLevel]) ?>
-            </li>
+            <?php echo $this->render('_list', ['model' => $children, 'maxLevel' => $maxLevel]) ?>
         <?php endforeach; ?>
     </ul>
 <?php endif; ?>


### PR DESCRIPTION
Removed redundant lines that are rendered within _list template.

Currently, the `<li>` tag is rendered twice for child elements which creates invalid HTML markup; two elements in the same document with the same ID attribute. Removing these lines fixes that issue.