### PR TITLE
skip the validation of parentId on deletion

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -38,7 +38,7 @@ class Module extends \yii\base\Module
     {
         parent::init();
 
-        if ($this->userIdentityClass === null) {
+        if (null === $this->userIdentityClass) {
             $this->userIdentityClass = Yii::$app->getUser()->identityClass;
         }
     }

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -131,6 +131,7 @@ class DefaultController extends Controller
     public function actionDelete($id)
     {
         $commentModel = $this->findModel($id);
+        $commentModel->setScenario(CommentModel::SCENARIO_MODERATION);
         $event = Yii::createObject(['class' => CommentEvent::class, 'commentModel' => $commentModel]);
         $this->trigger(self::EVENT_BEFORE_DELETE, $event);
 

--- a/controllers/DefaultController.php
+++ b/controllers/DefaultController.php
@@ -131,6 +131,7 @@ class DefaultController extends Controller
     public function actionDelete($id)
     {
         $commentModel = $this->findModel($id);
+        $commentModel->setScenario(CommentModel::SCENARIO_MODERATION);
         $event = Yii::createObject(['class' => CommentEvent::class, 'commentModel' => $commentModel]);
         $this->trigger(self::EVENT_BEFORE_DELETE, $event);
 
@@ -157,7 +158,7 @@ class DefaultController extends Controller
     protected function findModel($id)
     {
         $commentModel = $this->getModule()->commentModelClass;
-        if (($model = $commentModel::findOne($id)) !== null) {
+        if (null !== ($model = $commentModel::findOne($id))) {
             return $model;
         } else {
             throw new NotFoundHttpException(Yii::t('yii2mod.comments', 'The requested page does not exist.'));
@@ -176,7 +177,7 @@ class DefaultController extends Controller
     protected function getCommentAttributesFromEntity($entity)
     {
         $decryptEntity = Yii::$app->getSecurity()->decryptByKey(utf8_decode($entity), $this->getModule()->id);
-        if ($decryptEntity !== false) {
+        if (false !== $decryptEntity) {
             return Json::decode($decryptEntity);
         }
 

--- a/controllers/ManageController.php
+++ b/controllers/ManageController.php
@@ -142,7 +142,7 @@ class ManageController extends Controller
     {
         $commentModel = $this->getModule()->commentModelClass;
 
-        if (($model = $commentModel::findOne($id)) !== null) {
+        if (null !== ($model = $commentModel::findOne($id))) {
             return $model;
         } else {
             throw new NotFoundHttpException(Yii::t('yii2mod.comments', 'The requested page does not exist.'));

--- a/migrations/m010101_100001_init_comment.php
+++ b/migrations/m010101_100001_init_comment.php
@@ -14,7 +14,7 @@ class m010101_100001_init_comment extends Migration
     {
         $tableOptions = null;
 
-        if ($this->db->driverName === 'mysql') {
+        if ('mysql' === $this->db->driverName) {
             $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
         }
 

--- a/migrations/m161109_092304_rename_comment_table.php
+++ b/migrations/m161109_092304_rename_comment_table.php
@@ -6,14 +6,14 @@ class m161109_092304_rename_comment_table extends Migration
 {
     public function up()
     {
-        if (Yii::$app->db->schema->getTableSchema('{{%comment}}') === null) {
+        if (null === Yii::$app->db->schema->getTableSchema('{{%comment}}')) {
             $this->renameTable('{{%Comment}}', '{{%comment}}');
         }
     }
 
     public function down()
     {
-        if (Yii::$app->db->schema->getTableSchema('{{%Comment}}') === null) {
+        if (null === Yii::$app->db->schema->getTableSchema('{{%Comment}}')) {
             $this->renameTable('{{%comment}}', '{{%Comment}}');
         }
     }

--- a/models/CommentModel.php
+++ b/models/CommentModel.php
@@ -42,6 +42,8 @@ class CommentModel extends ActiveRecord
 {
     use ModuleTrait;
 
+    const SCENARIO_MODERATION = 'moderation';
+
     /**
      * @var null|array|ActiveRecord[] comment children
      */
@@ -67,7 +69,7 @@ class CommentModel extends ActiveRecord
             ['status', 'default', 'value' => Status::APPROVED],
             ['status', 'in', 'range' => Status::getConstantsByName()],
             ['level', 'default', 'value' => 1],
-            ['parentId', 'validateParentID'],
+            ['parentId', 'validateParentID', 'except'=>static::SCENARIO_MODERATION],
             [['entityId', 'parentId', 'status', 'level'], 'integer'],
         ];
     }

--- a/models/CommentModel.php
+++ b/models/CommentModel.php
@@ -42,6 +42,8 @@ class CommentModel extends ActiveRecord
 {
     use ModuleTrait;
 
+    const SCENARIO_MODERATION = 'moderation';
+
     /**
      * @var null|array|ActiveRecord[] comment children
      */
@@ -67,7 +69,7 @@ class CommentModel extends ActiveRecord
             ['status', 'default', 'value' => Status::APPROVED],
             ['status', 'in', 'range' => Status::getConstantsByName()],
             ['level', 'default', 'value' => 1],
-            ['parentId', 'validateParentID'],
+            ['parentId', 'validateParentID', 'except' => static::SCENARIO_MODERATION],
             [['entityId', 'parentId', 'status', 'level'], 'integer'],
         ];
     }
@@ -77,7 +79,7 @@ class CommentModel extends ActiveRecord
      */
     public function validateParentID($attribute)
     {
-        if ($this->{$attribute} !== null) {
+        if (null !== $this->{$attribute}) {
             $parentCommentExist = static::find()
                 ->approved()
                 ->andWhere([

--- a/views/manage/index.php
+++ b/views/manage/index.php
@@ -16,7 +16,7 @@ $this->params['breadcrumbs'][] = $this->title;
 ?>
 <div class="comments-index">
 
-    <h1><?php echo Html::encode($this->title) ?></h1>
+    <h1><?php echo Html::encode($this->title); ?></h1>
     <?php Pjax::begin(['timeout' => 10000]); ?>
     <?php echo GridView::widget([
         'dataProvider' => $dataProvider,

--- a/views/manage/update.php
+++ b/views/manage/update.php
@@ -15,7 +15,7 @@ $this->params['breadcrumbs'][] = Yii::t('yii2mod.comments', 'Update');
 ?>
 <div class="comment-update">
 
-    <h1><?php echo Html::encode($this->title) ?></h1>
+    <h1><?php echo Html::encode($this->title); ?></h1>
 
     <div class="comment-form">
         <?php $form = ActiveForm::begin(); ?>
@@ -30,7 +30,7 @@ $this->params['breadcrumbs'][] = Yii::t('yii2mod.comments', 'Update');
         ?>
         <?php echo $form->field($model, 'status')->dropDownList(Status::listData()); ?>
         <div class="form-group">
-            <?php echo Html::submitButton(Yii::t('yii2mod.comments', 'Update'), ['class' => 'btn btn-primary']) ?>
+            <?php echo Html::submitButton(Yii::t('yii2mod.comments', 'Update'), ['class' => 'btn btn-primary']); ?>
             <?php echo Html::a(Yii::t('yii2mod.comments', 'Go Back'), ['index'], ['class' => 'btn btn-default']); ?>
         </div>
         <?php ActiveForm::end(); ?>

--- a/widgets/views/_form.php
+++ b/widgets/views/_form.php
@@ -20,7 +20,7 @@ use yii\widgets\ActiveForm;
         'validateOnBlur' => false,
     ]); ?>
 
-    <?php echo $form->field($commentModel, 'content', ['template' => '{input}{error}'])->textarea(['placeholder' => Yii::t('yii2mod.comments', 'Add a comment...'), 'rows' => 4, 'data' => ['comment' => 'content']]) ?>
+    <?php echo $form->field($commentModel, 'content', ['template' => '{input}{error}'])->textarea(['placeholder' => Yii::t('yii2mod.comments', 'Add a comment...'), 'rows' => 4, 'data' => ['comment' => 'content']]); ?>
     <?php echo $form->field($commentModel, 'parentId', ['template' => '{input}'])->hiddenInput(['data' => ['comment' => 'parent-id']]); ?>
     <div class="comment-box-partial">
         <div class="button-container show">

--- a/widgets/views/_list.php
+++ b/widgets/views/_list.php
@@ -9,7 +9,7 @@ use yii2mod\editable\Editable;
 /* @var $maxLevel null|integer comments max level */
 ?>
 <li class="comment" id="comment-<?php echo $model->id; ?>">
-    <div class="comment-content" data-comment-content-id="<?php echo $model->id ?>">
+    <div class="comment-content" data-comment-content-id="<?php echo $model->id; ?>">
         <div class="comment-author-avatar">
             <?php echo Html::img($model->getAvatar(), ['alt' => $model->getAuthorName()]); ?>
         </div>


### PR DESCRIPTION
#77 Using a model scenario for moderation will fix the issue, when searching for a parent comment that is already deleted. 