### PR TITLE
Fix copy&paste error in translation

### DIFF
--- a/messages/en/yii2mod.comments.php
+++ b/messages/en/yii2mod.comments.php
@@ -25,7 +25,7 @@ return [
     'Status' => 'Status',
     'Level' => 'Level',
     'Created by' => 'Created by',
-    'Updated by' => 'Related to',
+    'Updated by' => 'Updated by',
     'Related to' => 'Related to',
     'Url' => 'Url',
     'Created date' => 'Created date',


### PR DESCRIPTION
Fixed translation of `'Updated by' => 'Related to'` by changing it to `'Updated by' => 'Updated by'`